### PR TITLE
Copy the PHARs before comparing them

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "email":    "info@paragonie.com",
         "source":   "https://github.com/paragonie/pharaoh"
     },
-    "bin": "pharaoh",
+    "bin": ["pharaoh"],
     "autoload": {
         "psr-4": {
             "ParagonIE\\Pharaoh\\": "src/Pharaoh/"

--- a/src/Pharaoh/Pharaoh.php
+++ b/src/Pharaoh/Pharaoh.php
@@ -47,12 +47,16 @@ class Pharaoh
             self::$stubfile = Hex::encode(\random_bytes(12)).'.pharstub';
         }
         
-        $this->phar = new \Phar($file);
-        
         if (empty($alias)) {
             // We have to give every one a different alias, or it pukes.
             $alias = Hex::encode(\random_bytes(16)).'.phar';
         }
+
+        if (!\copy($file, $tmpFile = \sys_get_temp_dir().\DIRECTORY_SEPARATOR.$alias)) {
+            throw new \Error('Could not create temporary file');
+        }
+
+        $this->phar = new \Phar($tmpFile);
         $this->phar->setAlias($alias);
         
         // Make a random folder in /tmp
@@ -61,17 +65,25 @@ class Pharaoh
         if (!\is_string($tmp)) {
             throw new \Error('Could not create temporary file');
         }
+
         $this->tmp = $tmp;
         \unlink($this->tmp);
-        \mkdir($this->tmp, 0755, true);
+        if (!mkdir($this->tmp, 0755, true) && !is_dir($this->tmp)) {
+            throw new \Error('Could not create temporary directory');
+        }
         
         // Let's extract to our temporary directory
         $this->phar->extractTo($this->tmp);
-        
+
         // Also extract the stub
         \file_put_contents(
             $this->tmp . '/' . self::$stubfile,
             $this->phar->getStub()
         );
+    }
+
+    public function __destruct()
+    {
+        \Phar::unlinkArchive($this->phar->getPath());
     }
 }

--- a/src/Pharaoh/Pharaoh.php
+++ b/src/Pharaoh/Pharaoh.php
@@ -68,7 +68,7 @@ class Pharaoh
 
         $this->tmp = $tmp;
         \unlink($this->tmp);
-        if (!mkdir($this->tmp, 0755, true) && !is_dir($this->tmp)) {
+        if (!\mkdir($this->tmp, 0755, true) && !\is_dir($this->tmp)) {
             throw new \Error('Could not create temporary directory');
         }
         


### PR DESCRIPTION
The PHARs requires to have a different alias hence Pharaoh set a unique alias. It however alters the
orignal PHAR which is not desirable. This patch copies the PHAR to a temporary directory first and
compare this copy instead.

Closes #6