### PR TITLE
Unset Phar before unliking it

### DIFF
--- a/src/Pharaoh/Pharaoh.php
+++ b/src/Pharaoh/Pharaoh.php
@@ -84,6 +84,9 @@ class Pharaoh
 
     public function __destruct()
     {
-        \Phar::unlinkArchive($this->phar->getPath());
+        $path = $this->phar->getPath();
+        unset($this->phar);
+
+        \Phar::unlinkArchive($path);
     }
 }


### PR DESCRIPTION
I'm not sure why this was not popping out earlier when I tried #8 with Box, but right now `Phar::unlinkArchive()` fails because the property `$phar` is still set resulting in:

```
PharException: phar archive "/path/to/myphar.phar" has open file handles or objects.  fclose() all file handles, and unset() all objects prior to calling unlinkArchive()
```

This patch successfully worked for me.